### PR TITLE
ExternalProjectDependency: Ignore CACHE value of type INTERNAL

### DIFF
--- a/ExternalProjectDependency.cmake
+++ b/ExternalProjectDependency.cmake
@@ -271,9 +271,15 @@ function(_sb_cmakevar_to_cmakearg cmake_varname_and_type cmake_arg_var has_cfg_i
   _sb_extract_varname_and_vartype(${cmake_varname_and_type} _varname _vartype)
 
   set(_var_value "${${_varname}}")
-  get_property(_value_set_in_cache CACHE ${_varname} PROPERTY VALUE SET)
-  if(_value_set_in_cache)
-    get_property(_var_value CACHE ${_varname} PROPERTY VALUE)
+
+  # Use cache value unless it is INTERNAL
+  if(_vartype STREQUAL "INTERNAL")
+    set(_vartype "STRING")
+  else()
+    get_property(_value_set_in_cache CACHE ${_varname} PROPERTY VALUE SET)
+    if(_value_set_in_cache)
+      get_property(_var_value CACHE ${_varname} PROPERTY VALUE)
+    endif()
   endif()
 
   set(_has_cfg_intdir FALSE)

--- a/Tests/MarkAsSuperBuild-Test/CMakeLists.txt
+++ b/Tests/MarkAsSuperBuild-Test/CMakeLists.txt
@@ -89,6 +89,13 @@ if(${PROJECT_NAME}_SUPERBUILD)
   set(WITHCOLON_VAR "c:/path/to/something" CACHE PATH "Variable with colon")
   mark_as_superbuild(WITHCOLON_VAR)
 
+  # Using cmake_dependent_option internally sets an INTERNAL cache value used to keep track of the
+  # previous value set by the user. mark_as_superbuild will ignore INTERNAL cache value and instead
+  # pass the non-cached value.
+  set(VAR_WITH_INTERNAL_CACHE OFF CACHE INTERNAL "")
+  set(VAR_WITH_INTERNAL_CACHE ON)
+  mark_as_superbuild(VAR_WITH_INTERNAL_CACHE)
+
   ExternalProject_DeclareLabels(LABELS "DECLARED_LABEL_NO_VAR_MAINPROJECT")
   ExternalProject_DeclareLabels(LABELS "DECLARED_LABEL_NO_VAR_LibA" PROJECTS LibA)
   ExternalProject_DeclareLabels(ALL_PROJECTS LABELS "DECLARED_LABEL_NO_VAR_ALL_PROJECTS")
@@ -161,6 +168,8 @@ check_variable(${_ALL_PROJECT_IDENTIFIER}_EP_LABEL_ALLPROJECT "ALL_PROJECTS_VAR_
 check_variable(ALL_PROJECTS_VAR_WITH_LABELS "AllProjectsVarWithLabels")
 
 check_variable(WITHCOLON_VAR "c:/path/to/something")
+
+check_variable(VAR_WITH_INTERNAL_CACHE "ON")
 
 # ExternalProject_DeclareLabels tests
 check_variable_defined("MarkAsSuperBuild-Test_EP_LABEL_DECLARED_LABEL_NO_VAR_MAINPROJECT")


### PR DESCRIPTION
Using cmake_dependent_option internally sets an INTERNAL cache value used
to keep track of the previous value set by the user. mark_as_superbuild
will ignore INTERNAL cache value and instead pass the non-cached value.