### PR TITLE
ExternalProjectDependency: Set DOWNLOAD_EXTRACT_TIMESTAMP to 1 if CMake >= 3.24

### DIFF
--- a/ExternalProjectDependency.cmake
+++ b/ExternalProjectDependency.cmake
@@ -525,6 +525,10 @@ function(_sb_get_external_project_arguments proj varname)
         )
     endforeach()
   endif()
+  if(CMAKE_VERSION VERSION_EQUAL "3.24" OR CMAKE_VERSION VERSION_GREATER "3.24")
+    # See https://cmake.org/cmake/help/latest/policy/CMP0135.html
+    list(APPEND _ep_arguments DOWNLOAD_EXTRACT_TIMESTAMP 1)
+  endif()
   set(${varname} ${_ep_arguments} PARENT_SCOPE)
 endfunction()
 

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,8 @@ Features
 
 * Automatically set external options ``LIST_SEPARATOR``, ``CMAKE_GENERATOR``, ``CMAKE_GENERATOR_PLATFORM`` and ``CMAKE_GENERATOR_TOOLSET``.
 
+* If CMake >= 3.24, set ``DOWNLOAD_EXTRACT_TIMESTAMP`` to ``1``. See `CMP0135 <https://cmake.org/cmake/help/latest/policy/CMP0135.html>`_
+
 * If not explicitly enabled, ensure ``User Package Registry`` look up using ``find_*`` commands is disabled.
 
   * If CMake >= 3.16, set ``CMAKE_FIND_USE_PACKAGE_REGISTRY`` to ``OFF`` otherwise set ``CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY`` to ``ON``.


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/policy/CMP0135.html

This will avoid warnings like the following:

```
CMake Warning (dev) at /path/to/cmake-3.26.4-linux-x86_64/share/cmake-3.26/Modules/ExternalProject.cmake:3091 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
```

Related discussion:
* https://github.com/KitwareMedical/vpaw/pull/33#issuecomment-1656082318