### PR TITLE
ci: Update CI workflow runner from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         # 3.4.x: Excluded because of "error while loading shared libraries: libidn.so.11: cannot open shared object file: No such file or directory"
         cmake-version: [
           "2.8.x",


### PR DESCRIPTION
The `ubuntu-20.04` runner was retired in in April 2025:

> The Ubuntu 20.04 Actions runner image will begin deprecation on
> 2025-02-01 and will be fully unsupported by 2025-04-15
>
> Source: https://github.com/actions/runner-images/issues/11101